### PR TITLE
Implement nix flake compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,50 @@ Download pre-built standalone packages directly from [GitHub Releases](https://g
   ```bash
   sudo pacman -U mastui-<version>-1-x86_64.pkg.tar.zst
   ```
+- **Nix (Flakes):**
+  Temporarily build and install via nix flakes
+  ```sh
+  nix run github:kimusan/mastui
+  ```
+  Or add to flake inputs and install:
+
+  flake.nix
+  ```nix
+  {
+    inputs = {
+      nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+      mastui = {
+        url = "github:kimusan/mastui";
+      };
+    };
+
+    outputs =
+      inputs@{
+      self,
+      nixpkgs,
+      ...
+      }:
+      {
+        # ...flake outputs
+      };
+  }
+  ```
+
+  configuration.nix
+  ```nix
+  environment.systemPackages = with pkgs; [
+    inputs.mastui."${pkgs.stdenv.hostPlatform.system}".default
+  ]
+  ```
+
+  or
+
+  home.nix
+  ```nix
+  home.packages = with pkgs; [
+    inputs.mastui."${pkgs.stdenv.hostPlatform.system}".default
+  ]
+  ```
 - **Windows**:
   Download `mastui-<version>-windows-x86_64.zip`, extract, and run `mastui.exe` in Windows Terminal or PowerShell.
 
@@ -222,7 +266,7 @@ Have an idea? Feel free to [open an issue](https://github.com/kimusan/mastui/iss
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please read `CONTRIBUTING.md` for details on our code of conduct and the process for submitting pull requests.
+Contributions are welcome! Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) for details on our code of conduct and the process for submitting pull requests.
 
 ## 🛠️ Technology Stack
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,58 @@
+{
+  fetchFromGitHub,
+  buildPythonPackage,
+  lib,
+  poetry-core,
+  pillow,
+  beautifulsoup4,
+  clipman,
+  html2text,
+  httpx,
+  mastodon-py,
+  python-dateutil,
+  python-dotenv,
+  requests,
+  textual,
+  textual-image,
+  toml,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "mastui";
+  version = "1.13.0";
+  pyproject = true;
+  build-system = [ poetry-core ];
+
+  src = ./.;
+
+  pythonRelaxDeps = [
+    "pillow"
+    "html2text"
+    "httpx"
+    "textual-image"
+  ];
+
+  propagatedBuildInputs = [
+    pillow
+    html2text
+    httpx
+    textual-image
+    poetry-core
+    beautifulsoup4
+    clipman
+    mastodon-py
+    python-dateutil
+    python-dotenv
+    requests
+    textual
+    toml
+  ];
+
+  meta = {
+    description = "A TUI client for mastodon written in python";
+    longDescription = "A powerful, feature-rich, and beautiful Mastodon TUI client.";
+    homepage = "https://mastui.app/";
+    mainProgram = "mastui";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kimusan ];
+  };
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "A powerful, feature-rich, and beautiful Mastodon TUI client.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    inputs@{ self, nixpkgs, ... }:
+    let
+      forAllSystems =
+        function:
+        nixpkgs.lib.genAttrs [
+          "x86_64-linux"
+          "aarch64-linux"
+        ] (system: function nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: {
+        default = pkgs.python3Packages.callPackage ./default.nix { };
+      });
+
+    };
+}


### PR DESCRIPTION
This PR implements nix flake compatibility whereby any system with the nix
package manager and nix flakes enabled can either:
1. Ephmerally build and run the application on their system
2. Install the application as a flake and run it as if it were installed
   natively

This isn't a replacement for native nix packaging through nixpkgs, but an
alternative that allows for some more flexibility.

Please let me know any questions I can answer.

Thanks for reading 🙏🏾
